### PR TITLE
4to8_loader: Add bin and df_out arguments to make

### DIFF
--- a/src/tools/msemu_4to8_loader/README.md
+++ b/src/tools/msemu_4to8_loader/README.md
@@ -8,9 +8,24 @@ It is compiled with an org of 0x4000 and it designed to have a binary appended t
 
 Note that it requires dataflash.bin set up to run an app from 0x0000, aka dataflash page 0, address 0. See other resources in this git for more info. FIXME: specify the location of said resources.
 
+```
 make
 cat /path/to/other.bin >> msemu_4to8_loader.bin
 dd if=msemu_4to8_loader.bin of=/path/to/msemu/dataflash.bin conv=notrunc
+```
+
+This can all be accomplished in a single line:
+
+`make bin=/path/to/other.bin df_out=/path/to/msemu/dataflash.bin`
+
+This will clean, rebuild, append the desired binary, and write it to the dataflash.
+Note that this will always write to offset 0 of the dataflash. This might not be what you want, but in most cases it will be.
+
+It is also possible to build the loader with the binary appended to it, this is useful if the resulting binary needs to be written to a custom location in dataflash.
+
+`make bin=/path/to/other.bin`
+
+This will output `msemu_4to8_loader-app.bin` with the loader and the binary appended together.
 
 
 # Bugs

--- a/src/tools/msemu_4to8_loader/makefile
+++ b/src/tools/msemu_4to8_loader/makefile
@@ -4,7 +4,18 @@ CFLAGS = -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x4000
 AS = sdasz80
 ASFLAGS = -lso
 
-all: clean msemu_4to8_loader.bin
+all: clean msemu_4to8_loader.bin append_bin write_df
+
+append_bin: msemu_4to8_loader.bin
+ifdef bin
+	cat $< $(bin)  > msemu_4to8_loader-app.bin
+endif
+
+write_df: append_bin
+ifdef df_out
+	@echo Writing application to start of dataflash
+	dd if=msemu_4to8_loader-app.bin of=$(df_out) conv=notrunc
+endif
 
 %.bin: %.ihx
 	objcopy -Iihex -Obinary $< $@


### PR DESCRIPTION
The path specified by bin= will append this binary to the
4to8_loader binary. Adding df_out= to that will write the resulting
total binary to the start of the specified dataflash path.